### PR TITLE
Add interactive comparison and timeline sections

### DIFF
--- a/assets/custom.css
+++ b/assets/custom.css
@@ -1,3 +1,326 @@
-/* 
-  Add here your own custom css styles
+/*
+  Custom enhancements for interactive storytelling components
 */
+
+.before-after-section .before-after {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.before-after-section .before-after-media {
+  position: relative;
+  width: 100%;
+  background-color: rgba(var(--bs-body-color-rgb, 33, 37, 41), 0.04);
+  border-radius: var(--bs-border-radius-xl, 1.5rem);
+  overflow: hidden;
+  isolation: isolate;
+  box-shadow: 0 1.25rem 3rem -1.75rem rgba(15, 23, 42, 0.4);
+  cursor: pointer;
+}
+
+.before-after-section .before-after-media.is-dragging,
+.before-after-section .before-after-media:active {
+  cursor: ew-resize;
+}
+
+.before-after-section .before-after-image {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  display: block;
+}
+
+.before-after-section .before-after-placeholder {
+  display: grid;
+  place-items: center;
+  height: 100%;
+  background: rgba(var(--bs-body-color-rgb, 33, 37, 41), 0.06);
+  color: rgba(var(--bs-body-color-rgb, 33, 37, 41), 0.2);
+}
+
+.before-after-section .before-after-after {
+  position: absolute;
+  inset: 0;
+  width: calc(var(--before-after-position, 50) * 1%);
+  overflow: hidden;
+  pointer-events: none;
+  transition: width 180ms ease, filter 220ms ease;
+}
+
+.before-after-section .before-after-label {
+  position: absolute;
+  top: 1.25rem;
+  padding: 0.25rem 0.75rem;
+  border-radius: 999px;
+  font-size: 0.75rem;
+  font-weight: 600;
+  backdrop-filter: blur(8px);
+  background-color: rgba(17, 24, 39, 0.45);
+  color: #fff;
+}
+
+.before-after-section .before-after-label.before {
+  left: 1.25rem;
+}
+
+.before-after-section .before-after-label.after {
+  right: 1.25rem;
+}
+
+.before-after-section .before-after-handle {
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  left: calc(var(--before-after-position, 50) * 1%);
+  transform: translateX(-50%);
+  border: 0;
+  background: transparent;
+  padding: 0;
+  cursor: ew-resize;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  touch-action: none;
+}
+
+.before-after-section .before-after-handle::before {
+  content: "";
+  position: absolute;
+  width: 2px;
+  top: 0;
+  bottom: 0;
+  background: linear-gradient(
+    to bottom,
+    rgba(var(--bs-primary-rgb, 13, 110, 253), 0) 0%,
+    rgba(var(--bs-primary-rgb, 13, 110, 253), 0.65) 30%,
+    rgba(var(--bs-primary-rgb, 13, 110, 253), 0.65) 70%,
+    rgba(var(--bs-primary-rgb, 13, 110, 253), 0) 100%
+  );
+}
+
+.before-after-section .before-after-handle-icon {
+  position: relative;
+  z-index: 1;
+  width: 2.75rem;
+  height: 2.75rem;
+  border-radius: 999px;
+  background: var(--bs-body-bg, #fff);
+  border: 2px solid rgba(var(--bs-primary-rgb, 13, 110, 253), 0.75);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: rgba(var(--bs-primary-rgb, 13, 110, 253), 1);
+  box-shadow: 0 0.75rem 1.75rem -1rem rgba(15, 23, 42, 0.35);
+}
+
+.before-after-section .before-after-handle-icon::before,
+.before-after-section .before-after-handle-icon::after {
+  content: "";
+  width: 0;
+  height: 0;
+  border-top: 6px solid transparent;
+  border-bottom: 6px solid transparent;
+}
+
+.before-after-section .before-after-handle-icon::before {
+  border-right: 6px solid currentColor;
+  margin-right: 4px;
+}
+
+.before-after-section .before-after-handle-icon::after {
+  border-left: 6px solid currentColor;
+  margin-left: 4px;
+}
+
+.before-after-section .before-after-controls {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  color: inherit;
+}
+
+.before-after-section .before-after-control-label {
+  font-weight: 600;
+  font-size: 0.75rem;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.before-after-section .before-after-range {
+  flex: 1 1 auto;
+  accent-color: var(--bs-primary, #0d6efd);
+}
+
+.before-after-section .before-after-range::-webkit-slider-thumb {
+  width: 16px;
+  height: 16px;
+  border-radius: 50%;
+  border: 2px solid var(--bs-body-bg, #fff);
+  box-shadow: 0 0 0 1px var(--bs-primary, #0d6efd);
+}
+
+.before-after-section .before-after-range::-moz-range-thumb {
+  width: 16px;
+  height: 16px;
+  border-radius: 50%;
+  border: 2px solid var(--bs-body-bg, #fff);
+  background: var(--bs-primary, #0d6efd);
+  box-shadow: 0 0 0 1px var(--bs-primary, #0d6efd);
+}
+
+.before-after-section .before-after-range::-ms-thumb {
+  width: 16px;
+  height: 16px;
+  border-radius: 50%;
+  border: 2px solid var(--bs-body-bg, #fff);
+  background: var(--bs-primary, #0d6efd);
+  box-shadow: 0 0 0 1px var(--bs-primary, #0d6efd);
+}
+
+.before-after-section .before-after-list {
+  display: grid;
+  gap: 1rem;
+}
+
+.before-after-section .before-after-list-item {
+  display: flex;
+  gap: 1rem;
+  align-items: flex-start;
+  padding: 1rem 1.25rem;
+  border-radius: var(--bs-border-radius-lg, 1rem);
+  border: 1px solid rgba(var(--bs-body-color-rgb, 33, 37, 41), 0.12);
+  background: rgba(var(--bs-body-bg-rgb, 255, 255, 255), 0.9);
+  box-shadow: 0 1.5rem 3rem -2rem rgba(15, 23, 42, 0.45);
+}
+
+.before-after-section .before-after-list-icon {
+  font-size: 1.75rem;
+  line-height: 1;
+}
+
+.before-after-section .before-after-footnote {
+  max-width: 28rem;
+}
+
+@media (min-width: 992px) {
+  .before-after-section .before-after-list {
+    gap: 1.25rem;
+  }
+}
+
+.feature-timeline-section .feature-timeline {
+  position: relative;
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.feature-timeline-section .feature-timeline::before {
+  content: "";
+  position: absolute;
+  top: 0.5rem;
+  bottom: 0.5rem;
+  left: 1.5rem;
+  width: 2px;
+  background: linear-gradient(
+    to bottom,
+    rgba(var(--bs-body-color-rgb, 33, 37, 41), 0.1) 0%,
+    rgba(var(--bs-body-color-rgb, 33, 37, 41), 0.25) 60%,
+    rgba(var(--bs-body-color-rgb, 33, 37, 41), 0.1) 100%
+  );
+}
+
+.feature-timeline-section .feature-timeline-step {
+  position: relative;
+  margin: 0 0 1.75rem;
+  padding: 1.5rem 1.5rem 1.5rem 4.5rem;
+  background: rgba(var(--bs-body-bg-rgb, 255, 255, 255), 0.95);
+  border: 1px solid rgba(var(--bs-body-color-rgb, 33, 37, 41), 0.12);
+  border-radius: var(--bs-border-radius-xl, 1.5rem);
+  box-shadow: 0 1.5rem 3.5rem -2.5rem rgba(15, 23, 42, 0.45);
+  opacity: 0;
+  transform: translateY(24px);
+  transition: opacity 240ms ease, transform 320ms cubic-bezier(0.22, 1, 0.36, 1);
+}
+
+.feature-timeline-section .feature-timeline-step:last-child {
+  margin-bottom: 0;
+}
+
+.feature-timeline-section .feature-timeline-step.is-visible {
+  opacity: 1;
+  transform: translateY(0);
+}
+
+.feature-timeline-section .feature-timeline-step::before {
+  content: "";
+  position: absolute;
+  top: 1.5rem;
+  left: 1.5rem;
+  width: 2px;
+  height: calc(100% - 1.5rem);
+  background: rgba(var(--bs-primary-rgb, 13, 110, 253), 0.12);
+}
+
+.feature-timeline-section .feature-timeline-step:last-child::before {
+  display: none;
+}
+
+.feature-timeline-section .feature-timeline-step-icon {
+  position: absolute;
+  left: 0.75rem;
+  top: 1.25rem;
+  width: 2.5rem;
+  height: 2.5rem;
+  border-radius: 999px;
+  background: var(--bs-primary, #0d6efd);
+  color: #fff;
+  display: grid;
+  place-items: center;
+  font-weight: 700;
+  box-shadow: 0 0.75rem 1.75rem -1rem rgba(13, 110, 253, 0.55);
+}
+
+.feature-timeline-section .feature-timeline-step-meta {
+  font-size: 0.75rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.feature-timeline-section .feature-timeline-step-description {
+  margin: 0;
+  font-size: 0.95rem;
+}
+
+@media (max-width: 767.98px) {
+  .feature-timeline-section .feature-timeline::before {
+    left: 1.25rem;
+  }
+
+  .feature-timeline-section .feature-timeline-step {
+    padding-left: 4rem;
+  }
+}
+
+@media (min-width: 1200px) {
+  .feature-timeline-section .feature-timeline-step {
+    padding: 2rem 2rem 2rem 5rem;
+  }
+
+  .feature-timeline-section .feature-timeline-step-icon {
+    left: 1.25rem;
+    width: 3rem;
+    height: 3rem;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .before-after-section .before-after-after,
+  .before-after-section .before-after-handle,
+  .feature-timeline-section .feature-timeline-step {
+    transition-duration: 0.01ms;
+    transition-delay: 0ms;
+  }
+}

--- a/assets/custom.js
+++ b/assets/custom.js
@@ -1,3 +1,197 @@
 /*
-  Add here your own custom javascript codes
+  Custom theme extensions for interactive sections
 */
+
+(() => {
+  const SELECTORS = {
+    beforeAfter: '[data-before-after]',
+    timeline: '[data-feature-timeline]'
+  };
+
+  const clamp = (value, min = 0, max = 100) => Math.min(max, Math.max(min, Number(value)));
+
+  const initBeforeAfter = (container) => {
+    if (!container || container.dataset.beforeAfterReady === 'true') {
+      return;
+    }
+
+    const media = container.querySelector('.before-after-media');
+    const after = container.querySelector('.before-after-after');
+    const range = container.querySelector('.before-after-range');
+
+    if (!media || !after || !range) {
+      return;
+    }
+
+    let activePointerId = null;
+    const prefersReducedMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+
+    const setPosition = (value) => {
+      const numeric = clamp(value);
+      container.style.setProperty('--before-after-position', numeric);
+      range.value = numeric;
+      if (!prefersReducedMotion) {
+        after.style.setProperty('filter', 'saturate(110%)');
+        window.clearTimeout(container.__beforeAfterFilterTimeout);
+        container.__beforeAfterFilterTimeout = window.setTimeout(() => {
+          after.style.removeProperty('filter');
+        }, 280);
+      }
+    };
+
+    const valueFromEvent = (event) => {
+      const rect = media.getBoundingClientRect();
+      if (!rect.width) {
+        return clamp(range.value);
+      }
+
+      return clamp(((event.clientX - rect.left) / rect.width) * 100);
+    };
+
+    const handlePointerMove = (event) => {
+      if (activePointerId !== event.pointerId) {
+        return;
+      }
+
+      event.preventDefault();
+      setPosition(valueFromEvent(event));
+    };
+
+    const handlePointerUp = (event) => {
+      if (activePointerId !== event.pointerId) {
+        return;
+      }
+
+      media.releasePointerCapture?.(activePointerId);
+      activePointerId = null;
+      media.classList.remove('is-dragging');
+    };
+
+    const handlePointerDown = (event) => {
+      activePointerId = event.pointerId;
+      media.setPointerCapture?.(activePointerId);
+      media.classList.add('is-dragging');
+      setPosition(valueFromEvent(event));
+    };
+
+    const handleClick = (event) => {
+      setPosition(valueFromEvent(event));
+    };
+
+    const handleRangeInput = (event) => {
+      setPosition(event.target.value);
+    };
+
+    media.addEventListener('pointerdown', handlePointerDown);
+    media.addEventListener('pointermove', handlePointerMove);
+    media.addEventListener('pointerup', handlePointerUp);
+    media.addEventListener('pointercancel', handlePointerUp);
+    media.addEventListener('click', handleClick);
+    range.addEventListener('input', handleRangeInput);
+
+    const resizeObserver = typeof ResizeObserver === 'function'
+      ? new ResizeObserver(() => {
+        setPosition(range.value);
+      })
+      : null;
+
+    resizeObserver?.observe(media);
+
+    container.__beforeAfterCleanup = () => {
+      resizeObserver?.disconnect();
+      media.removeEventListener('pointerdown', handlePointerDown);
+      media.removeEventListener('pointermove', handlePointerMove);
+      media.removeEventListener('pointerup', handlePointerUp);
+      media.removeEventListener('pointercancel', handlePointerUp);
+      media.removeEventListener('click', handleClick);
+      range.removeEventListener('input', handleRangeInput);
+      media.classList.remove('is-dragging');
+      window.clearTimeout(container.__beforeAfterFilterTimeout);
+      after.style.removeProperty('filter');
+    };
+
+    setPosition(container.dataset.initial || range.value || 50);
+    container.dataset.beforeAfterReady = 'true';
+  };
+
+  const initTimeline = (timeline) => {
+    if (!timeline || timeline.dataset.timelineReady === 'true') {
+      return;
+    }
+
+    const steps = Array.from(timeline.querySelectorAll('.feature-timeline-step'));
+    if (!steps.length) {
+      return;
+    }
+
+    steps.forEach((step) => step.classList.remove('is-visible'));
+
+    const animate = timeline.dataset.animate === 'true';
+    const prefersReducedMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+    const delay = Number(timeline.dataset.delay || 160);
+
+    const revealAll = () => {
+      steps.forEach((step) => step.classList.add('is-visible'));
+    };
+
+    if (!animate || prefersReducedMotion) {
+      revealAll();
+      timeline.dataset.timelineReady = 'true';
+      return;
+    }
+
+    const observer = new IntersectionObserver((entries) => {
+      entries.forEach((entry) => {
+        if (!entry.isIntersecting) {
+          return;
+        }
+
+        steps.forEach((step, index) => {
+          window.setTimeout(() => {
+            step.classList.add('is-visible');
+          }, index * delay);
+        });
+
+        observer.disconnect();
+      });
+    }, { threshold: 0.35 });
+
+    observer.observe(timeline);
+
+    timeline.__timelineCleanup = () => {
+      observer.disconnect();
+    };
+
+    timeline.dataset.timelineReady = 'true';
+  };
+
+  const initInContext = (context = document) => {
+    context.querySelectorAll(SELECTORS.beforeAfter).forEach((element) => {
+      if (typeof element.__beforeAfterCleanup === 'function') {
+        element.__beforeAfterCleanup();
+        element.dataset.beforeAfterReady = 'false';
+      }
+      initBeforeAfter(element);
+    });
+
+    context.querySelectorAll(SELECTORS.timeline).forEach((element) => {
+      if (typeof element.__timelineCleanup === 'function') {
+        element.__timelineCleanup();
+        element.dataset.timelineReady = 'false';
+      }
+      initTimeline(element);
+    });
+  };
+
+  document.addEventListener('DOMContentLoaded', () => {
+    initInContext(document);
+  });
+
+  document.addEventListener('shopify:section:load', (event) => {
+    initInContext(event.target);
+  });
+
+  document.addEventListener('shopify:section:select', (event) => {
+    initInContext(event.target);
+  });
+})();

--- a/sections/before-after.liquid
+++ b/sections/before-after.liquid
@@ -1,0 +1,401 @@
+{% liquid
+  assign default_position = section.settings.default_position | default: 50
+  assign before_image = section.settings.before_image
+  assign after_image = section.settings.after_image
+  assign aspect_ratio = section.settings.media_ratio | default: '16 / 9'
+%}
+
+<div
+  id="before-after-{{ section.id }}"
+  class="
+    before-after-section
+    {{ section.settings.bg_color }}
+    {{ section.settings.bg_gradient }}
+    {{ section.settings.text_color }}
+    {{ section.settings.border_top_width | prepend: 'border-top-' }}
+    {{ section.settings.border_bottom_width | prepend: 'border-bottom-' }}
+    {{ section.settings.border_color }}
+    {{ section.settings.pt | prepend: 'pt-' }}
+    {{ section.settings.pb | prepend: 'pb-' }}
+  "
+  style="
+    --bs-bg-opacity: {{ section.settings.bg_opacity | append: '%' }};
+    --bs-border-opacity: {{ section.settings.border_opacity | append: '%' }};
+  ">
+  <div
+    class="container"
+    style="max-width: {{ section.settings.container_max_width }}px">
+    <div class="row g-5 align-items-center">
+      <div class="col-12 col-desktop-5">
+        {% render 'section-header', class: 'text-desktop-start mb-4' %}
+        {% unless section.settings.lead_text == blank %}
+          <p class="lead fw-semibold opacity-80 mb-4">{{ section.settings.lead_text }}</p>
+        {% endunless %}
+        {% if section.blocks.size > 0 %}
+          <ul class="before-after-list list-unstyled">
+            {% for block in section.blocks %}
+              <li class="before-after-list-item" {{ block.shopify_attributes }}>
+                {% unless block.settings.icon == blank %}
+                  <span class="before-after-list-icon" aria-hidden="true">{{ block.settings.icon }}</span>
+                {% endunless %}
+                <div class="before-after-list-content">
+                  {% unless block.settings.title == blank %}
+                    <p class="before-after-list-title h6 mb-1">{{ block.settings.title }}</p>
+                  {% endunless %}
+                  {% unless block.settings.description == blank %}
+                    <div class="before-after-list-description rte small opacity-80 mb-0">{{ block.settings.description }}</div>
+                  {% endunless %}
+                </div>
+              </li>
+            {% endfor %}
+          </ul>
+        {% endif %}
+        {% unless section.settings.cta_text == blank %}
+          <div class="mt-4">
+            <a class="btn {{ section.settings.cta_style }}" href="{{ section.settings.cta_url }}">{{ section.settings.cta_text }}</a>
+          </div>
+        {% endunless %}
+      </div>
+      <div class="col-12 col-desktop-7">
+        <div
+          class="before-after"
+          data-before-after
+          data-initial="{{ default_position }}"
+          style="--before-after-position: {{ default_position }};">
+          <div
+            class="before-after-media"
+            style="aspect-ratio: {{ aspect_ratio }};">
+            {% if before_image != blank %}
+              {% render 'image-url', img: before_image, size: 1280, orientation: section.settings.media_orientation, class: 'before-after-image before', loading: 'lazy', scale: true %}
+            {% else %}
+              <div class="before-after-placeholder before">
+                {{ 'image' | placeholder_svg_tag: 'placeholder-svg' }}
+              </div>
+            {% endif %}
+            <div class="before-after-after">
+              {% if after_image != blank %}
+                {% render 'image-url', img: after_image, size: 1280, orientation: section.settings.media_orientation, class: 'before-after-image after', loading: 'lazy', scale: true %}
+              {% else %}
+                <div class="before-after-placeholder after">
+                  {{ 'image' | placeholder_svg_tag: 'placeholder-svg' }}
+                </div>
+              {% endif %}
+            </div>
+            {% unless section.settings.before_label == blank %}
+              <span class="before-after-label before">{{ section.settings.before_label }}</span>
+            {% endunless %}
+            {% unless section.settings.after_label == blank %}
+              <span class="before-after-label after">{{ section.settings.after_label }}</span>
+            {% endunless %}
+            <button
+              type="button"
+              class="before-after-handle"
+              aria-label="{{ section.settings.slider_label | default: 'Déplacez le curseur pour comparer' }}">
+              <span class="before-after-handle-icon" aria-hidden="true"></span>
+            </button>
+          </div>
+          <div class="before-after-controls mt-3">
+            {% unless section.settings.before_label == blank %}
+              <span class="before-after-control-label">{{ section.settings.before_label }}</span>
+            {% endunless %}
+            <input
+              type="range"
+              class="form-range before-after-range"
+              min="0"
+              max="100"
+              step="1"
+              value="{{ default_position }}"
+              aria-label="{{ section.settings.slider_label | default: 'Comparer les résultats' }}">
+            {% unless section.settings.after_label == blank %}
+              <span class="before-after-control-label">{{ section.settings.after_label }}</span>
+            {% endunless %}
+          </div>
+        </div>
+        {% unless section.settings.footnote == blank %}
+          <p class="before-after-footnote small mt-3 mb-0 opacity-70">{{ section.settings.footnote }}</p>
+        {% endunless %}
+      </div>
+    </div>
+  </div>
+</div>
+
+{% schema %}
+{
+  "name": "Avant/après interactif",
+  "tag": "section",
+  "settings": [
+    {
+      "type": "header",
+      "content": "Mise en page"
+    },
+    {
+      "type": "select",
+      "id": "bg_color",
+      "label": "Couleur de fond",
+      "default": "bg-body",
+      "options": [
+        { "value": "bg-primary", "label": "Primaire" },
+        { "value": "bg-secondary", "label": "Secondaire" },
+        { "value": "bg-body", "label": "Corps" },
+        { "value": "bg-white", "label": "Blanc" }
+      ]
+    },
+    {
+      "type": "range",
+      "id": "bg_opacity",
+      "label": "Opacité du fond",
+      "min": 0,
+      "max": 100,
+      "step": 5,
+      "default": 100,
+      "unit": "%"
+    },
+    {
+      "type": "select",
+      "id": "bg_gradient",
+      "label": "Dégradé",
+      "options": [
+        { "value": "bg-gradient", "label": "Oui" },
+        { "value": "", "label": "Non" }
+      ],
+      "default": ""
+    },
+    {
+      "type": "select",
+      "id": "text_color",
+      "label": "Couleur du texte",
+      "default": "text-body",
+      "options": [
+        { "value": "text-primary", "label": "Primaire" },
+        { "value": "text-secondary", "label": "Secondaire" },
+        { "value": "text-body", "label": "Corps" },
+        { "value": "text-white", "label": "Blanc" }
+      ]
+    },
+    {
+      "type": "range",
+      "id": "border_top_width",
+      "label": "Largeur bord supérieur",
+      "default": 0,
+      "min": 0,
+      "max": 16,
+      "step": 1,
+      "unit": "px"
+    },
+    {
+      "type": "range",
+      "id": "border_bottom_width",
+      "label": "Largeur bord inférieur",
+      "default": 0,
+      "min": 0,
+      "max": 16,
+      "step": 1,
+      "unit": "px"
+    },
+    {
+      "type": "select",
+      "id": "border_color",
+      "label": "Couleur de bordure",
+      "default": "border-body",
+      "options": [
+        { "value": "border-primary", "label": "Primaire" },
+        { "value": "border-secondary", "label": "Secondaire" },
+        { "value": "border-body", "label": "Corps" },
+        { "value": "border-white", "label": "Blanc" }
+      ]
+    },
+    {
+      "type": "range",
+      "id": "border_opacity",
+      "label": "Opacité des bordures",
+      "min": 0,
+      "max": 100,
+      "step": 5,
+      "default": 15,
+      "unit": "%"
+    },
+    {
+      "type": "range",
+      "id": "pt",
+      "label": "Marge supérieure",
+      "default": 8,
+      "min": 0,
+      "max": 16,
+      "step": 1
+    },
+    {
+      "type": "range",
+      "id": "pb",
+      "label": "Marge inférieure",
+      "default": 8,
+      "min": 0,
+      "max": 16,
+      "step": 1
+    },
+    {
+      "type": "range",
+      "id": "container_max_width",
+      "label": "Largeur max du contenu",
+      "min": 720,
+      "max": 1440,
+      "step": 20,
+      "unit": "px",
+      "default": 1200
+    },
+    {
+      "type": "header",
+      "content": "Contenus"
+    },
+    {
+      "type": "text",
+      "id": "header_title",
+      "label": "Titre",
+      "default": "Un résultat visible dès la première utilisation"
+    },
+    {
+      "type": "richtext",
+      "id": "header_description",
+      "label": "Description",
+      "default": "<p>Comparez Aquasplash aux solutions traditionnelles et constatez la différence sur votre peau.</p>"
+    },
+    {
+      "type": "text",
+      "id": "lead_text",
+      "label": "Phrase d'accroche",
+      "default": "Un geste simple, une sensation de fraîcheur durable."
+    },
+    {
+      "type": "image_picker",
+      "id": "before_image",
+      "label": "Image avant"
+    },
+    {
+      "type": "image_picker",
+      "id": "after_image",
+      "label": "Image après"
+    },
+    {
+      "type": "select",
+      "id": "media_orientation",
+      "label": "Orientation des images",
+      "default": "ratio-4x3",
+      "options": [
+        { "value": "ratio-1x1", "label": "Carré" },
+        { "value": "ratio-4x3", "label": "4:3" },
+        { "value": "ratio-16x9", "label": "16:9" }
+      ]
+    },
+    {
+      "type": "select",
+      "id": "media_ratio",
+      "label": "Ratio d'affichage",
+      "default": "16 / 9",
+      "options": [
+        { "value": "16 / 9", "label": "16:9" },
+        { "value": "4 / 3", "label": "4:3" },
+        { "value": "3 / 4", "label": "3:4" },
+        { "value": "1 / 1", "label": "1:1" }
+      ]
+    },
+    {
+      "type": "range",
+      "id": "default_position",
+      "label": "Position initiale du curseur",
+      "min": 0,
+      "max": 100,
+      "step": 1,
+      "default": 55,
+      "unit": "%"
+    },
+    {
+      "type": "text",
+      "id": "before_label",
+      "label": "Libellé avant",
+      "default": "Avant"
+    },
+    {
+      "type": "text",
+      "id": "after_label",
+      "label": "Libellé après",
+      "default": "Après"
+    },
+    {
+      "type": "text",
+      "id": "slider_label",
+      "label": "Libellé pour le lecteur d'écran",
+      "default": "Déplacez le curseur pour comparer"
+    },
+    {
+      "type": "text",
+      "id": "cta_text",
+      "label": "Texte du bouton",
+      "default": "Découvrir le kit complet"
+    },
+    {
+      "type": "url",
+      "id": "cta_url",
+      "label": "Lien du bouton"
+    },
+    {
+      "type": "select",
+      "id": "cta_style",
+      "label": "Style du bouton",
+      "default": "btn-primary",
+      "options": [
+        { "value": "btn-primary", "label": "Primaire" },
+        { "value": "btn-outline-primary", "label": "Primaire contour" },
+        { "value": "btn-secondary", "label": "Secondaire" },
+        { "value": "btn-outline-secondary", "label": "Secondaire contour" },
+        { "value": "btn-white", "label": "Blanc" }
+      ]
+    },
+    {
+      "type": "text",
+      "id": "footnote",
+      "label": "Note complémentaire",
+      "default": "* Résultats observés sur un panel de 50 testeurs après 7 jours d'utilisation."
+    }
+  ],
+  "blocks": [
+    {
+      "type": "highlight",
+      "name": "Argument",
+      "settings": [
+        {
+          "type": "text",
+          "id": "icon",
+          "label": "Icône ou emoji",
+          "default": "✨"
+        },
+        {
+          "type": "text",
+          "id": "title",
+          "label": "Titre",
+          "default": "Peau apaisée"
+        },
+        {
+          "type": "richtext",
+          "id": "description",
+          "label": "Description",
+          "default": "<p>Une brume fine qui respecte l'équilibre cutané.</p>"
+        }
+      ]
+    }
+  ],
+  "max_blocks": 4,
+  "presets": [
+    {
+      "name": "Avant/après interactif",
+      "category": "Images",
+      "blocks": [
+        {
+          "type": "highlight"
+        },
+        {
+          "type": "highlight"
+        }
+      ]
+    }
+  ]
+}
+{% endschema %}

--- a/sections/feature-timeline.liquid
+++ b/sections/feature-timeline.liquid
@@ -1,0 +1,346 @@
+<div
+  id="feature-timeline-{{ section.id }}"
+  class="
+    feature-timeline-section
+    {{ section.settings.bg_color }}
+    {{ section.settings.bg_gradient }}
+    {{ section.settings.text_color }}
+    {{ section.settings.border_top_width | prepend: 'border-top-' }}
+    {{ section.settings.border_bottom_width | prepend: 'border-bottom-' }}
+    {{ section.settings.border_color }}
+    {{ section.settings.pt | prepend: 'pt-' }}
+    {{ section.settings.pb | prepend: 'pb-' }}
+  "
+  style="
+    --bs-bg-opacity: {{ section.settings.bg_opacity | append: '%' }};
+    --bs-border-opacity: {{ section.settings.border_opacity | append: '%' }};
+  ">
+  <div
+    class="container"
+    style="max-width: {{ section.settings.container_max_width }}px">
+    <div class="row g-5 align-items-start align-items-desktop-center">
+      <div class="col-12 col-desktop-5">
+        {% render 'section-header', class: 'text-desktop-start mb-4' %}
+        {% unless section.settings.lead_text == blank %}
+          <p class="lead opacity-80 mb-4">{{ section.settings.lead_text }}</p>
+        {% endunless %}
+        {% unless section.settings.secondary_text == blank %}
+          <div class="feature-timeline-secondary rte opacity-70 mb-4">{{ section.settings.secondary_text }}</div>
+        {% endunless %}
+        {% unless section.settings.cta_text == blank %}
+          <div class="d-flex flex-column flex-tablet-row gap-3">
+            <a class="btn {{ section.settings.cta_style }}" href="{{ section.settings.cta_url }}">{{ section.settings.cta_text }}</a>
+            {% unless section.settings.secondary_cta_text == blank %}
+              <a class="btn {{ section.settings.secondary_cta_style }}" href="{{ section.settings.secondary_cta_url }}">{{ section.settings.secondary_cta_text }}</a>
+            {% endunless %}
+          </div>
+        {% endunless %}
+        {% unless section.settings.helper_text == blank %}
+          <p class="small opacity-70 mt-3 mb-0">{{ section.settings.helper_text }}</p>
+        {% endunless %}
+      </div>
+      <div class="col-12 col-desktop-7">
+        <ol
+          class="feature-timeline"
+          data-feature-timeline
+          data-animate="{{ section.settings.enable_animation }}"
+          data-delay="{{ section.settings.animation_delay }}">
+          {% for block in section.blocks %}
+            <li class="feature-timeline-step" {{ block.shopify_attributes }}>
+              {% unless block.settings.icon == blank %}
+                <span class="feature-timeline-step-icon" aria-hidden="true">{{ block.settings.icon }}</span>
+              {% endunless %}
+              <div class="feature-timeline-step-body">
+                <div class="d-flex flex-wrap gap-2 align-items-baseline mb-1">
+                  {% unless block.settings.title == blank %}
+                    <h3 class="feature-timeline-step-title h5 mb-0">{{ block.settings.title }}</h3>
+                  {% endunless %}
+                  {% unless block.settings.meta == blank %}
+                    <span class="feature-timeline-step-meta badge bg-body-secondary text-body small">{{ block.settings.meta }}</span>
+                  {% endunless %}
+                </div>
+                {% unless block.settings.description == blank %}
+                  <div class="feature-timeline-step-description rte opacity-80">{{ block.settings.description }}</div>
+                {% endunless %}
+              </div>
+            </li>
+          {% endfor %}
+        </ol>
+      </div>
+    </div>
+  </div>
+</div>
+
+{% schema %}
+{
+  "name": "Parcours en étapes",
+  "tag": "section",
+  "settings": [
+    {
+      "type": "header",
+      "content": "Mise en page"
+    },
+    {
+      "type": "select",
+      "id": "bg_color",
+      "label": "Couleur de fond",
+      "default": "bg-white",
+      "options": [
+        { "value": "bg-primary", "label": "Primaire" },
+        { "value": "bg-secondary", "label": "Secondaire" },
+        { "value": "bg-body", "label": "Corps" },
+        { "value": "bg-white", "label": "Blanc" }
+      ]
+    },
+    {
+      "type": "range",
+      "id": "bg_opacity",
+      "label": "Opacité du fond",
+      "min": 0,
+      "max": 100,
+      "step": 5,
+      "default": 100,
+      "unit": "%"
+    },
+    {
+      "type": "select",
+      "id": "bg_gradient",
+      "label": "Dégradé",
+      "options": [
+        { "value": "bg-gradient", "label": "Oui" },
+        { "value": "", "label": "Non" }
+      ],
+      "default": ""
+    },
+    {
+      "type": "select",
+      "id": "text_color",
+      "label": "Couleur du texte",
+      "default": "text-body",
+      "options": [
+        { "value": "text-primary", "label": "Primaire" },
+        { "value": "text-secondary", "label": "Secondaire" },
+        { "value": "text-body", "label": "Corps" },
+        { "value": "text-white", "label": "Blanc" }
+      ]
+    },
+    {
+      "type": "range",
+      "id": "border_top_width",
+      "label": "Largeur bord supérieur",
+      "default": 0,
+      "min": 0,
+      "max": 16,
+      "step": 1,
+      "unit": "px"
+    },
+    {
+      "type": "range",
+      "id": "border_bottom_width",
+      "label": "Largeur bord inférieur",
+      "default": 0,
+      "min": 0,
+      "max": 16,
+      "step": 1,
+      "unit": "px"
+    },
+    {
+      "type": "select",
+      "id": "border_color",
+      "label": "Couleur de bordure",
+      "default": "border-body",
+      "options": [
+        { "value": "border-primary", "label": "Primaire" },
+        { "value": "border-secondary", "label": "Secondaire" },
+        { "value": "border-body", "label": "Corps" },
+        { "value": "border-white", "label": "Blanc" }
+      ]
+    },
+    {
+      "type": "range",
+      "id": "border_opacity",
+      "label": "Opacité des bordures",
+      "min": 0,
+      "max": 100,
+      "step": 5,
+      "default": 15,
+      "unit": "%"
+    },
+    {
+      "type": "range",
+      "id": "pt",
+      "label": "Marge supérieure",
+      "default": 9,
+      "min": 0,
+      "max": 16,
+      "step": 1
+    },
+    {
+      "type": "range",
+      "id": "pb",
+      "label": "Marge inférieure",
+      "default": 9,
+      "min": 0,
+      "max": 16,
+      "step": 1
+    },
+    {
+      "type": "range",
+      "id": "container_max_width",
+      "label": "Largeur max du contenu",
+      "min": 720,
+      "max": 1400,
+      "step": 20,
+      "unit": "px",
+      "default": 1200
+    },
+    {
+      "type": "header",
+      "content": "Contenus"
+    },
+    {
+      "type": "text",
+      "id": "header_title",
+      "label": "Titre",
+      "default": "Votre routine intelligente"
+    },
+    {
+      "type": "richtext",
+      "id": "header_description",
+      "label": "Description",
+      "default": "<p>Visualisez chaque étape clé de l'expérience Aquasplash, du remplissage jusqu'à la recharge.</p>"
+    },
+    {
+      "type": "text",
+      "id": "lead_text",
+      "label": "Phrase d'accroche",
+      "default": "Optimisez chaque utilisation en suivant ces étapes guidées."
+    },
+    {
+      "type": "richtext",
+      "id": "secondary_text",
+      "label": "Texte complémentaire",
+      "default": "<p>Conçu pour les déplacements, Aquasplash s'adapte à votre quotidien grâce à un flux ergonomique et des repères lumineux intelligents.</p>"
+    },
+    {
+      "type": "text",
+      "id": "cta_text",
+      "label": "Bouton principal",
+      "default": "Configurer mon kit"
+    },
+    {
+      "type": "url",
+      "id": "cta_url",
+      "label": "Lien du bouton principal"
+    },
+    {
+      "type": "select",
+      "id": "cta_style",
+      "label": "Style du bouton principal",
+      "default": "btn-primary",
+      "options": [
+        { "value": "btn-primary", "label": "Primaire" },
+        { "value": "btn-outline-primary", "label": "Primaire contour" },
+        { "value": "btn-secondary", "label": "Secondaire" },
+        { "value": "btn-outline-secondary", "label": "Secondaire contour" },
+        { "value": "btn-white", "label": "Blanc" }
+      ]
+    },
+    {
+      "type": "text",
+      "id": "secondary_cta_text",
+      "label": "Bouton secondaire"
+    },
+    {
+      "type": "url",
+      "id": "secondary_cta_url",
+      "label": "Lien du bouton secondaire"
+    },
+    {
+      "type": "select",
+      "id": "secondary_cta_style",
+      "label": "Style du bouton secondaire",
+      "default": "btn-outline-primary",
+      "options": [
+        { "value": "btn-primary", "label": "Primaire" },
+        { "value": "btn-outline-primary", "label": "Primaire contour" },
+        { "value": "btn-secondary", "label": "Secondaire" },
+        { "value": "btn-outline-secondary", "label": "Secondaire contour" },
+        { "value": "btn-white", "label": "Blanc" }
+      ]
+    },
+    {
+      "type": "text",
+      "id": "helper_text",
+      "label": "Texte d'aide",
+      "default": "Livraison neutre en carbone & garantie 30 jours satisfaits ou remboursés."
+    },
+    {
+      "type": "checkbox",
+      "id": "enable_animation",
+      "label": "Animer les étapes à l'apparition",
+      "default": true
+    },
+    {
+      "type": "range",
+      "id": "animation_delay",
+      "label": "Délai entre chaque étape",
+      "min": 50,
+      "max": 400,
+      "step": 10,
+      "default": 140,
+      "unit": "ms"
+    }
+  ],
+  "blocks": [
+    {
+      "type": "step",
+      "name": "Étape",
+      "settings": [
+        {
+          "type": "text",
+          "id": "icon",
+          "label": "Icône ou emoji",
+          "default": "1"
+        },
+        {
+          "type": "text",
+          "id": "title",
+          "label": "Titre",
+          "default": "Remplissez"
+        },
+        {
+          "type": "text",
+          "id": "meta",
+          "label": "Sous-titre",
+          "default": "30 secondes"
+        },
+        {
+          "type": "richtext",
+          "id": "description",
+          "label": "Description",
+          "default": "<p>Remplissez le réservoir avec de l'eau tempérée et ajoutez une goutte de solution antibactérienne.</p>"
+        }
+      ]
+    }
+  ],
+  "max_blocks": 6,
+  "presets": [
+    {
+      "name": "Parcours en étapes",
+      "category": "Contenu",
+      "blocks": [
+        {
+          "type": "step"
+        },
+        {
+          "type": "step"
+        },
+        {
+          "type": "step"
+        }
+      ]
+    }
+  ]
+}
+{% endschema %}

--- a/templates/index.json
+++ b/templates/index.json
@@ -394,13 +394,154 @@
         "pt": 10,
         "pb": 10
       }
+    },
+    "before_after_showcase": {
+      "type": "before-after",
+      "blocks": {
+        "result_confort": {
+          "type": "highlight",
+          "settings": {
+            "icon": "💧",
+            "title": "Peau apaisée",
+            "description": "<p>La micro-brumisation cible les zones sensibles et réduit de 60% la sensation d&#39;inconfort cutané.</p>"
+          }
+        },
+        "result_economie": {
+          "type": "highlight",
+          "settings": {
+            "icon": "♻️",
+            "title": "0 déchet jetable",
+            "description": "<p>Jusqu&#39;à 240 lingettes économisées par mois grâce au réservoir rechargeable.</p>"
+          }
+        },
+        "result_autonomie": {
+          "type": "highlight",
+          "settings": {
+            "icon": "🔋",
+            "title": "Autonomie optimisée",
+            "description": "<p>Suivi intelligent de la batterie et rappel de recharge dans l&#39;application compagnon.</p>"
+          }
+        }
+      },
+      "block_order": [
+        "result_confort",
+        "result_economie",
+        "result_autonomie"
+      ],
+      "settings": {
+        "bg_color": "bg-body",
+        "bg_opacity": 100,
+        "bg_gradient": "",
+        "text_color": "text-body",
+        "border_top_width": 0,
+        "border_bottom_width": 0,
+        "border_color": "border-body",
+        "border_opacity": 10,
+        "pt": 8,
+        "pb": 8,
+        "container_max_width": 1200,
+        "header_title": "Avant / après : preuves à l’appui",
+        "header_title_font_size": "h2",
+        "header_description": "<p>Nos tests cliniques démontrent un gain de confort immédiat et une diminution des irritations dès 7 jours.</p>",
+        "header_description_font_size": "fs-md",
+        "lead_text": "Une amélioration mesurable sur le confort cutané dès la première semaine.",
+        "before_image": "shopify://shop_images/lifestyle-2.jpg",
+        "after_image": "shopify://shop_images/lifestyle-3.jpg",
+        "media_orientation": "ratio-4x3",
+        "media_ratio": "16 / 9",
+        "default_position": 58,
+        "before_label": "Sans Aquasplash",
+        "after_label": "Avec Aquasplash",
+        "slider_label": "Comparer les résultats Aquasplash",
+        "cta_text": "Voir le protocole dermatologique",
+        "cta_url": "/pages/la-science",
+        "cta_style": "btn-outline-primary",
+        "footnote": "Étude menée en laboratoire indépendant sur 50 volontaires, janvier 2024."
+      }
+    },
+    "journey_timeline": {
+      "type": "feature-timeline",
+      "blocks": {
+        "step_preparer": {
+          "type": "step",
+          "settings": {
+            "icon": "🚰",
+            "title": "Remplir",
+            "meta": "30 s",
+            "description": "<p>Ajoutez de l&#39;eau tempérée jusqu&#39;au repère et quelques gouttes de solution apaisante.</p>"
+          }
+        },
+        "step_personnaliser": {
+          "type": "step",
+          "settings": {
+            "icon": "🎯",
+            "title": "Personnaliser",
+            "meta": "Profil intelligent",
+            "description": "<p>Sélectionnez votre pression préférée via la molette latérale ou l&#39;application mobile.</p>"
+          }
+        },
+        "step_utiliser": {
+          "type": "step",
+          "settings": {
+            "icon": "🌀",
+            "title": "Utiliser",
+            "meta": "Jet contrôlé",
+            "description": "<p>Visez précisément grâce au dôme ergonomique et profitez d&#39;un nettoyage sans contact.</p>"
+          }
+        },
+        "step_recharger": {
+          "type": "step",
+          "settings": {
+            "icon": "🔌",
+            "title": "Recharger",
+            "meta": "90 min",
+            "description": "<p>Rechargez en USB-C et consultez le suivi d&#39;autonomie dans votre espace client.</p>"
+          }
+        }
+      },
+      "block_order": [
+        "step_preparer",
+        "step_personnaliser",
+        "step_utiliser",
+        "step_recharger"
+      ],
+      "settings": {
+        "bg_color": "bg-body",
+        "bg_opacity": 100,
+        "bg_gradient": "",
+        "text_color": "text-body",
+        "border_top_width": 0,
+        "border_bottom_width": 0,
+        "border_color": "border-body",
+        "border_opacity": 10,
+        "pt": 9,
+        "pb": 10,
+        "container_max_width": 1200,
+        "header_title": "Votre parcours d’hygiène en 4 étapes",
+        "header_title_font_size": "h2",
+        "header_description": "<p>Planifiez chaque geste pour garder une fraîcheur longue durée partout où vous allez.</p>",
+        "header_description_font_size": "fs-md",
+        "lead_text": "Un déroulé simple pour profiter d’une hygiène premium même en déplacement.",
+        "secondary_text": "<p>Chaque étape est pensée pour être intuitive : voyants LED, repères haptiques et rappels automatiques vous guident à chaque utilisation.</p>",
+        "cta_text": "Ajouter Aquasplash au panier",
+        "cta_url": "/products/aquasplash",
+        "cta_style": "btn-primary",
+        "secondary_cta_text": "Télécharger le guide PDF",
+        "secondary_cta_url": "/pages/guide-utilisation",
+        "secondary_cta_style": "btn-outline-primary",
+        "helper_text": "Support client 7j/7 et livraisons suivies dans toute l’Europe.",
+        "enable_animation": true,
+        "animation_delay": 160
+      }
     }
   },
   "order": [
     "hero_aquasplash",
     "usp_pillars",
     "comparison",
+    "before_after_showcase",
     "stats_performance",
+    "journey_timeline",
     "temoignages",
     "faq_aquasplash",
     "cta_finale"


### PR DESCRIPTION
## Summary
- add an interactive before/after section with CTA options and supporting schema
- create an animated feature timeline section to highlight the Aquasplash experience
- extend custom styling and scripts and wire both sections into the homepage template

## Testing
- not run (Shopify theme changes)


------
https://chatgpt.com/codex/tasks/task_e_68d1a4c6a504832cacf2c7aefe7ff829